### PR TITLE
Add missing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Nordnet follows Javascript styleguide suggested by Airbnb. See [Airbnb's Javascr
 
 Install plugin as dev dependency
 
-    npm install --save-dev eslint eslint-config-nordnet eslint-config-airbnb babel-eslint eslint-plugin-react
+    npm install --save-dev eslint eslint-config-nordnet eslint-config-airbnb babel-eslint eslint-plugin-react eslint-plugin-import eslint-plugin-import
 
 ## Configuration
 


### PR DESCRIPTION
When running ESlint after installing this NPM complains about 2 missing packages. Probably airbnb who added them upstream.